### PR TITLE
Feature/choose cost centre

### DIFF
--- a/core/templates/base_generic.html
+++ b/core/templates/base_generic.html
@@ -75,8 +75,8 @@
                         </a>
                     </li>
                     <li class="govuk-header__navigation-item {% if request.path == '/forecast/edit/' %}govuk-header__navigation-item--active{% endif %}">
-                        <a class="govuk-header__link" href="/forecast/edit/">
-                            Edit
+                        <a class="govuk-header__link" href="/forecast/choose-cost-centre/">
+                            Choose cost centre
                         </a>
                     </li>
                 </ul>

--- a/core/templates/core/govt_uk_form.html
+++ b/core/templates/core/govt_uk_form.html
@@ -1,0 +1,17 @@
+        {{ form.non_field_errors }}
+        {% for field in form %}
+            <div class="govuk-form-group{% if field.errors %} govuk-form-group--error{% endif %}">
+                <label class="govuk-label" for="{{ field.name }}">
+                    {{ field.label }}{% if field.field.required == False %} (optional){% endif %}
+                </label>
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <span id="{{ field.name }}-issued-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span>
+                            {{ error|escape }}
+                        </span>
+                    {% endfor %}
+                {% endif %}
+                {{ field }}
+            </div>
+        {% endfor %}

--- a/costcentre/forms.py
+++ b/costcentre/forms.py
@@ -1,0 +1,18 @@
+from django import forms
+from django.forms import Select
+
+from costcentre.models import CostCentre
+
+
+class ChooseCostCentreForm(forms.Form):
+    cost_centre = forms.ModelChoiceField(
+        queryset=CostCentre.objects.all(),
+        widget=Select(),
+    )
+
+    cost_centre.widget.attrs.update(
+        {
+            "class": "govuk-select",
+            "aria-describedby": "cost_centre-hint cost_centre-error",
+        }
+    )

--- a/costcentre/models.py
+++ b/costcentre/models.py
@@ -138,8 +138,15 @@ class CostCentre(TimeStampedModel, LogChangeModel):
     )
     used_for_travel = models.BooleanField("Used for Travel", default="True")
 
+    @property
+    def full_name(self):
+        return "{} - {}".format(
+            self.cost_centre_code,
+            self.cost_centre_name,
+        )
+
     def __str__(self):
-        return str(self.cost_centre_code) + " - " + str(self.cost_centre_name)
+        return self.full_name
 
     class Meta:
         verbose_name = "Cost Centre"

--- a/forecast/templates/forecast/add.html
+++ b/forecast/templates/forecast/add.html
@@ -3,23 +3,7 @@
 {% block page_content %}
     <form method="post" action="">
         {% csrf_token %}
-        {{ form.non_field_errors }}
-        {% for field in form %}
-            <div class="govuk-form-group{% if field.errors %} govuk-form-group--error{% endif %}">
-                <label class="govuk-label" for="{{ field.name }}">
-                    {{ field.label }}{% if field.field.required == False %} (optional){% endif %}
-                </label>
-                {% if field.errors %}
-                    {% for error in field.errors %}
-                        <span id="{{ field.name }}-issued-error" class="govuk-error-message">
-                            <span class="govuk-visually-hidden">Error:</span>
-                            {{ error|escape }}
-                        </span>
-                    {% endfor %}
-                {% endif %}
-                {{ field }}
-            </div>
-        {% endfor %}
+        {% include "core/govt_uk_form.html" %}
         <input type="submit" value="Add entry" class="govuk-button" data-module="govuk-button"/>
     </form>
 {% endblock %}

--- a/forecast/templates/forecast/choose_cost_centre.html
+++ b/forecast/templates/forecast/choose_cost_centre.html
@@ -1,0 +1,11 @@
+{% extends "wide_content.html" %}
+
+{% block content %}
+    <h3 class="govuk-heading-m">Choose cost centre</h3>
+    <form method="post" action ="">
+        {% csrf_token %}
+        {% include "core/govt_uk_form.html" %}
+        <input type="submit" value="Choose cost centre" class="govuk-button" data-module="govuk-button"/>
+    </form>
+
+{% endblock %}

--- a/forecast/templates/forecast/edit.html
+++ b/forecast/templates/forecast/edit.html
@@ -18,7 +18,7 @@
                     <p>AREA FOR DATA SELECTION</p>
                 </div>
                 <div class="govuk-grid-column-one-third">
-                    <a href="{% url 'add_forecast_row' %}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    <a href="{% url 'add_forecast_row' view.cost_centre_details.cost_centre_num %}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
                       Add a new row
                     </a>
                 </div>

--- a/forecast/test/test_views.py
+++ b/forecast/test/test_views.py
@@ -12,8 +12,9 @@ from chartofaccountDIT.test.factories import (
     NaturalCodeFactory,
 )
 
-# Nb. we're using RequestFactory here because SSO
-# does not fullt support the test client's user object
+# Nb. we're using RequestFactory here
+# because SSO does not fully support
+# the test client's user object
 
 
 class ViewPermissionsTest(TestCase):

--- a/forecast/test/test_views.py
+++ b/forecast/test/test_views.py
@@ -5,12 +5,15 @@ from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 
-from forecast.views import EditForecastView
+from forecast.views.forecast_views import EditForecastView
 from costcentre.test.factories import CostCentreFactory
 from chartofaccountDIT.test.factories import (
     ProgrammeCodeFactory,
     NaturalCodeFactory,
 )
+
+# Nb. we're using RequestFactory here because SSO
+# does not fullt support the test client's user object
 
 
 class ViewPermissionsTest(TestCase):
@@ -32,12 +35,26 @@ class ViewPermissionsTest(TestCase):
         self.test_user.set_password(self.test_password)
 
     def test_edit_forecast_view(self):
-        self.assertFalse(self.test_user.has_perm("change_costcentre", self.cost_centre))
+        self.assertFalse(self.test_user.has_perm(
+                "change_costcentre",
+                self.cost_centre
+            )
+        )
 
-        request = self.factory.get(reverse("edit_forecast"))
+        edit_forecast_url = reverse(
+            "edit_forecast",
+            kwargs={
+                'cost_centre_code': self.cost_centre_code
+            }
+        )
+
+        request = self.factory.get(edit_forecast_url)
         request.user = self.test_user
+        kwargs = {
+            'cost_centre_code': self.cost_centre_code
+        }  # required because factory does not pass kwargs to request
 
-        resp = EditForecastView.as_view()(request)
+        resp = EditForecastView.as_view()(request, **kwargs)
 
         # Should have been redirected (no permission)
         self.assertEqual(resp.status_code, 302)
@@ -48,10 +65,10 @@ class ViewPermissionsTest(TestCase):
         self.assertTrue(self.test_user.has_perm("change_costcentre", self.cost_centre))
         self.assertTrue(self.test_user.has_perm("view_costcentre", self.cost_centre))
 
-        request = self.factory.get(reverse("edit_forecast"))
+        request = self.factory.get(edit_forecast_url)
         request.user = self.test_user
 
-        resp = EditForecastView.as_view()(request)
+        resp = EditForecastView.as_view()(request, **kwargs)
 
         # Should be allowed
         self.assertEqual(resp.status_code, 200)
@@ -83,9 +100,19 @@ class AddForecastRowTest(TestCase):
         assign_perm("change_costcentre", self.test_user, self.cost_centre)
         assign_perm("view_costcentre", self.test_user, self.cost_centre)
 
-        request = self.factory.get(reverse("edit_forecast"))
+        edit_forecast_url = reverse(
+            "edit_forecast",
+            kwargs={
+                'cost_centre_code': self.cost_centre_code
+            }
+        )
+
+        request = self.factory.get(edit_forecast_url)
         request.user = self.test_user
-        edit_resp = EditForecastView.as_view()(request)
+        kwargs = {
+            'cost_centre_code': self.cost_centre_code
+        }  # required because factory does not pass kwargs to request
+        edit_resp = EditForecastView.as_view()(request, **kwargs)
 
         self.assertEqual(edit_resp.status_code, 200)
 
@@ -96,12 +123,24 @@ class AddForecastRowTest(TestCase):
         # There should only be 2 rows (for the header and footer)
         assert len(table_rows) == 2
 
-        add_resp = self.client.get(reverse("add_forecast_row"))
+        add_resp = self.client.get(
+            reverse(
+                "add_forecast_row",
+                kwargs={
+                    'cost_centre_code': self.cost_centre_code
+                },
+            )
+        )
         self.assertEqual(add_resp.status_code, 200)
 
         # add_forecast_row
         add_row_resp = self.client.post(
-            reverse("add_forecast_row"),
+            reverse(
+                "add_forecast_row",
+                kwargs={
+                    'cost_centre_code': self.cost_centre_code
+                },
+            ),
             {
                 "programme": self.programme.programme_code,
                 "natural_account_code": self.nac.natural_account_code,
@@ -117,3 +156,52 @@ class AddForecastRowTest(TestCase):
 
         # Now we should have 3 rows (header, footer and new row)
         assert len(table_rows) == 3
+
+
+class ChooseCostCentreTest(TestCase):
+    def setUp(self):
+        self.cost_centre_code = 888812
+        self.cost_centre = CostCentreFactory.create(
+            cost_centre_code=self.cost_centre_code
+        )
+
+    def test_view_choose_cost_centre(self):
+        resp = self.client.get(
+            reverse(
+                "choose_cost_centre"
+            )
+        )
+
+        self.assertEqual(
+            resp.status_code,
+            200,
+        )
+
+        resp = self.client.post(
+            reverse(
+                "choose_cost_centre"
+            ), {
+                "cost_centre": self.cost_centre_code
+            },
+            follow=True,
+        )
+
+        self.assertEqual(
+            resp.status_code,
+            200,
+        )
+
+        # If the post has worked, we will have been
+        # redirect twice, first to the edit page and
+        # then to the cost centre page (because we don't
+        # have permission to view the edit page)
+        self.assertEqual(
+            len(resp.redirect_chain),
+            2
+        )
+        assert resp.redirect_chain[0] == ('/forecast/edit/{}/'.format(
+                self.cost_centre_code,
+            ),
+            302,
+        )
+        assert resp.redirect_chain[1] == ('/forecast/costcentre/', 302)

--- a/forecast/urls.py
+++ b/forecast/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     path("pivotmulti/", MultiForecastView.as_view(), name="pivotmulti"),
     path("pivot1/", pivot_test1, name="pivot1"),
     path("edit/<int:cost_centre_code>/", EditForecastView.as_view(), name="edit_forecast"),
-    path("add/", AddRowView.as_view(), name="add_forecast_row"),
+    path("add/<int:cost_centre_code>/", AddRowView.as_view(), name="add_forecast_row"),
     path("edit-prototype/", edit_forecast_prototype, name="edit_prototype"),
     path("choose-cost-centre/", ChooseCostCentreView.as_view(), name="choose_cost_centre")
 ]

--- a/forecast/urls.py
+++ b/forecast/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from forecast.views import (
+from forecast.views.forecast_views import (
     CostClassView,
     MultiForecastView,
     PivotClassView,
@@ -9,13 +9,17 @@ from forecast.views import (
     EditForecastView,
     AddRowView,
 )
+from forecast.views.cost_centre_views import (
+    ChooseCostCentreView,
+)
 
 urlpatterns = [
     path("pivot/", PivotClassView.as_view(), name="pivot"),
     path("costcentre/", CostClassView.as_view(), name="costcentre"),
     path("pivotmulti/", MultiForecastView.as_view(), name="pivotmulti"),
     path("pivot1/", pivot_test1, name="pivot1"),
-    path("edit/", EditForecastView.as_view(), name="edit_forecast"),
+    path("edit/<int:cost_centre_code>/", EditForecastView.as_view(), name="edit_forecast"),
     path("add/", AddRowView.as_view(), name="add_forecast_row"),
     path("edit-prototype/", edit_forecast_prototype, name="edit_prototype"),
+    path("choose-cost-centre/", ChooseCostCentreView.as_view(), name="choose_cost_centre")
 ]

--- a/forecast/views/base.py
+++ b/forecast/views/base.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.shortcuts import redirect
+from django.views.generic.base import TemplateView
+
+from costcentre.models import CostCentre
+
+
+class NoCostCentreCodeInURLError(Exception):
+    pass
+
+
+class ForecastBaseView(UserPassesTestMixin, TemplateView):
+    cost_centre_code = None
+
+    def test_func(self):
+        if 'cost_centre_code' not in self.kwargs:
+            raise NoCostCentreCodeInURLError(
+                "No cost centre code provided in URL"
+            )
+
+        self.cost_centre_code = self.kwargs["cost_centre_code"]
+
+        cost_centre = CostCentre.objects.get(
+            cost_centre_code=self.kwargs["cost_centre_code"]
+        )
+
+        return self.request.user.has_perm(
+            "view_costcentre", cost_centre
+        ) and self.request.user.has_perm(
+            "change_costcentre",
+            cost_centre
+        )
+
+    def handle_no_permission(self):
+        return redirect("costcentre")

--- a/forecast/views/cost_centre_views.py
+++ b/forecast/views/cost_centre_views.py
@@ -1,0 +1,23 @@
+from django.views.generic.edit import FormView
+from django.urls import reverse
+
+from costcentre.forms import ChooseCostCentreForm
+
+
+class ChooseCostCentreView(FormView):
+    template_name = "forecast/choose_cost_centre.html"
+    form_class = ChooseCostCentreForm
+    cost_centre_code = None
+
+    def get_success_url(self):
+        cost_centre_code = self.request.POST.get(
+            'cost_centre',
+            None,
+        )
+        if cost_centre_code:
+            return reverse(
+                "edit_forecast",
+                kwargs={'cost_centre_code': cost_centre_code}
+            )
+
+        return None

--- a/forecast/views/forecast_views.py
+++ b/forecast/views/forecast_views.py
@@ -16,6 +16,8 @@ from forecast.models import MonthlyFigure, FinancialPeriod
 from forecast.tables import ForecastSubTotalTable, ForecastTable
 from forecast.forms import EditForm, AddForecastRowForm
 from core.views import FidoExportMixin
+from forecast.views.base import ForecastBaseView
+
 
 # programme__budget_type_fk__budget_type_display
 # indicates if DEL, AME, ADMIN used in every view
@@ -222,21 +224,8 @@ class AddRowView(FormView):
         return super().form_valid(form)
 
 
-class EditForecastView(UserPassesTestMixin, TemplateView):
+class EditForecastView(ForecastBaseView):
     template_name = "forecast/edit.html"
-    cost_centre_code = "888812"
-
-    def test_func(self):
-        cost_centre = CostCentre.objects.get(
-            cost_centre_code=self.cost_centre_code
-        )
-
-        return self.request.user.has_perm(
-            "view_costcentre", cost_centre
-        ) and self.request.user.has_perm("change_costcentre", cost_centre)
-
-    def handle_no_permission(self):
-        return redirect("costcentre")
 
     def cost_centre_details(self):
         return {

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ exclude = */migrations/*,__pycache__,manage.py,config/*,env/*,lib/*,bin/*,includ
 ignore = D100,D104,D106,D200,D203,D205,D400,D401,W503
 max-line-length = 88
 max-complexity = 10
-application-import-names = fido
+application-import-names = chartofaccountDIT,config,core,costcentre,downloadsupport,forecast,gifthospitality,importdata,payroll,trasuryCOA,treasurySS


### PR DESCRIPTION
This feature allows a user to select a cost centre. 

It also adds a mechanism to carry the chosen cost centre through to the add and edit cost centre pages.

In order to test, login as a user with permissions to edit a given cost centre and select "Choose cost centre" from the menu. You will be taken to a page with a drop down that allows you to select a cost centre. The add row function should work correctly.