### PR TITLE
Feature/swap defender for axes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -243,12 +243,13 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "core.no_cache_middleware.NoCacheMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
-    "axes.middleware.FailedLoginMiddleware",
+    "axes.middleware.AxesMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "guardian.backends.ObjectPermissionBackend",
+    "axes.backends.AxesBackend",
 ]
 
 AXES_LOGIN_FAILURE_LIMIT = 5

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -80,7 +80,7 @@ INSTALLED_APPS = [
     "reversion",
     "rest_framework",
     "simple_history",
-    "defender",
+    "axes",
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -232,8 +232,6 @@ SETTINGS_EXPORT = [
     'GTM_CODE',
 ]
 
-DEFENDER_REDIS_URL = env('DEFENDER_REDIS_URL', default='')
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -245,10 +243,12 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "core.no_cache_middleware.NoCacheMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
-    "defender.middleware.FailedLoginMiddleware",
+    "axes.middleware.FailedLoginMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
     "guardian.backends.ObjectPermissionBackend",
 ]
+
+AXES_LOGIN_FAILURE_LIMIT = 5

--- a/config/urls.py
+++ b/config/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
     path("pingdom/", include("pingdom.urls")),
     path("upload/", include("upload_file.urls")),
     path("admin/", admin.site.urls),
-    path("admin/defender/", include("defender.urls")),  # defender admin
     # TODO - split below out into develop only?
     path(
         "assets/<path:asset_path>",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -91,5 +91,5 @@ redis
 djangorestframework
 django-simple-history
 django-settings-export
-django-defender
+django-axes
 django-redis


### PR DESCRIPTION
Remove Django Defender and add Django Axes. Axes is configured for lockout after 5 attempts.