### PR TITLE
Add max and min values for forecast entries

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -261,3 +261,7 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 # s3chunkuploader
 FILE_UPLOAD_HANDLERS = ('s3chunkuploader.file_handler.S3FileUploadHandler',)
 CLEAN_FILE_NAME = True
+
+# Max and min for forecast entry values
+MAX_FORECAST_FIGURE = 100000000
+MIN_FORECAST_FIGURE = -100000000

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
@@ -360,8 +361,16 @@ class EditForecastFigureView(
             financial_period__financial_period_code=month,
         ).first()
 
+        amount = form.cleaned_data['amount']
+
+        if amount > settings.MAX_FORECAST_FIGURE:
+            amount = settings.MAX_FORECAST_FIGURE
+
+        if amount < settings.MIN_FORECAST_FIGURE:
+            amount = settings.MIN_FORECAST_FIGURE
+
         if monthly_figure:
-            monthly_figure.amount = form.cleaned_data['amount']
+            monthly_figure.amount = amount
         else:
             financial_period = FinancialPeriod.objects.filter(
                 financial_period_code=month
@@ -370,7 +379,7 @@ class EditForecastFigureView(
                 financial_year=financial_year,
                 financial_code=financial_code.first(),
                 financial_period=financial_period,
-                amount=form.cleaned_data['amount'],
+                amount=amount,
             )
 
         monthly_figure.save()

--- a/front_end/src/Components/EditActionBar/index.js
+++ b/front_end/src/Components/EditActionBar/index.js
@@ -81,7 +81,7 @@ const EditActionBar = () => {
                                     );
                                 }}
                             />
-                            <label className="govuk-label govuk-checkboxes__label" for="waste">
+                            <label className="govuk-label govuk-checkboxes__label" htmlFor="waste">
                                 All columns
                             </label>
                         </div>

--- a/front_end/src/Components/TableCell/index.js
+++ b/front_end/src/Components/TableCell/index.js
@@ -120,13 +120,23 @@ const TableCell = ({rowIndex, cellId, cellKey, sheetUpdating}) => {
 
 
     const updateValue = () => {
-        let newAmount = parseInt(value * 100)
+        let newAmount = value * 100
 
-        if (cell && newAmount === cell.amount) {
+        if (newAmount > Number.MAX_SAFE_INTEGER) {
+            newAmount = Number.MAX_SAFE_INTEGER
+        }
+
+        if (newAmount < Number.MIN_SAFE_INTEGER) {
+            newAmount = Number.MIN_SAFE_INTEGER
+        }
+
+        let intAmount = parseInt(newAmount)
+
+        if (cell && intAmount === cell.amount) {
             return
         }
 
-        if (!cell && newAmount === 0) {
+        if (!cell && intAmount === 0) {
             return
         }
 
@@ -140,7 +150,7 @@ const TableCell = ({rowIndex, cellId, cellKey, sheetUpdating}) => {
         payload.append("analysis2_code", cells[rowIndex]["analysis2_code"].value)
 
         payload.append("month", cellKey)
-        payload.append("amount", newAmount)
+        payload.append("amount", intAmount)
 
         postData(
             `/forecast/update-forecast/${window.cost_centre}/`,


### PR DESCRIPTION
Set max and min amounts for forecast entry values. The max and min are configurable in settings.