### PR TITLE
Remove database read for each cell displayed.

### DIFF
--- a/forecast/templatetags/forecast_format.py
+++ b/forecast/templatetags/forecast_format.py
@@ -1,6 +1,5 @@
 from django import template
 
-from forecast.models import FinancialPeriod
 from forecast.utils.view_header_definition import (
     budget_header,
     budget_spent_percentage_header,
@@ -16,13 +15,27 @@ forecast_figure_cols = [
     year_to_date_header,
     forecast_total_header,
     variance_header,
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Adj1',
+    'Adj2',
+    'Adj3',
 ]
 
 
 @register.filter()
 def is_forecast_figure(_, column):
-    if str(column) in FinancialPeriod.financial_period_info.period_display_list() \
-            or str(column) in forecast_figure_cols:
+    if str(column) in forecast_figure_cols:
         return True
 
     return False


### PR DESCRIPTION
Use a static list for finding month names, instead of reading them from the database.
