### PR TITLE
View forecast Cost Centre link from Edit Forecast page is too wide

### DIFF
--- a/core/static/core/css/styles.scss
+++ b/core/static/core/css/styles.scss
@@ -12,6 +12,10 @@ body {
   background-color: rgba(177, 180, 182, 0.5);
 }
 
+.cost-centre-heading-link {
+  display: inline;
+}
+
 .main-content {
   margin-top: 20px;
 }

--- a/forecast/templates/forecast/forecast_base.html
+++ b/forecast/templates/forecast/forecast_base.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="app-pane__content">
     <h1 class="govuk-heading-l">Edit forecast</h1>
-    <a href="{% url 'forecast_cost_centre' view.cost_centre_details.cost_centre_code %}" target="_blank" class="govuk-heading-m cost-centre-link">{{ view.cost_centre_details.cost_centre_name }} ({{ view.cost_centre_details.cost_centre_code }}) </a>
+    <a href="{% url 'forecast_cost_centre' view.cost_centre_details.cost_centre_code %}" target="_blank" class="govuk-heading-m cost-centre-heading-link">{{ view.cost_centre_details.cost_centre_name }} ({{ view.cost_centre_details.cost_centre_code }}) </a>
     <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/forecast/test/test_views.py
+++ b/forecast/test/test_views.py
@@ -1335,7 +1335,7 @@ class ViewEditTest(TestCase, RequestFactoryBase):
         response = self.client.get(view_forecast_url)
         assert response.status_code == 200
 
-        cost_centre_links = soup.find_all("a", class_="cost-centre-link")
+        cost_centre_links = soup.find_all("a", class_="cost-centre-heading-link")
 
         assert len(cost_centre_links) == 1
         assert cost_centre_links[0]['href'] == view_forecast_url


### PR DESCRIPTION
Visit https://fido.trade.uat.uktrade.io/forecast/edit/109003/ and the view forecast links spans the entire page width. Just the text should be linked.