### PR TITLE
Add link from FFT site to admin site when user's have permission to access admin

### DIFF
--- a/core/templates/base_generic.html
+++ b/core/templates/base_generic.html
@@ -156,6 +156,14 @@
                     </li>
                     {% endif %}
                 {% endif %}
+
+            {% if request.user.is_staff %}
+                <li class="internal-header__navigation__item">
+                    <a target="_blank" id="admin_page" class="internal-header__navigation__item__link" href="{% url 'admin:index' %}">
+                                Admin Site
+                    </a>
+                </li>
+            {% endif %}
             </ul>
         </nav>
     </div>

--- a/core/test/test_views.py
+++ b/core/test/test_views.py
@@ -23,7 +23,7 @@ class ViewAdminLink(TestCase, RequestFactoryBase):
         Test admin user can view Admin link in navigation bar
         """
         # Create staff user
-        self.test_user.is_staff
+        self.test_user.is_staff = True
         self.test_user.save()
 
         view_homepage = reverse(
@@ -35,7 +35,7 @@ class ViewAdminLink(TestCase, RequestFactoryBase):
 
         soup = BeautifulSoup(response.content, features="html.parser")
 
-        admin_link = soup.find_all("a", class_="admin_page")
+        admin_link = soup.find_all("a", id="admin_page")
 
         assert len(admin_link) == 1
 
@@ -53,6 +53,6 @@ class ViewAdminLink(TestCase, RequestFactoryBase):
 
         soup = BeautifulSoup(response.content, features="html.parser")
 
-        admin_link = soup.find_all("a", class_="admin_page")
+        admin_link = soup.find_all("a", id="admin_page")
 
         assert len(admin_link) == 0

--- a/core/test/test_views.py
+++ b/core/test/test_views.py
@@ -6,6 +6,7 @@ from django.test import (
     TestCase,
 )
 from django.urls import reverse
+
 from core.test.test_base import RequestFactoryBase
 
 

--- a/core/test/test_views.py
+++ b/core/test/test_views.py
@@ -1,1 +1,58 @@
 # TODO - Test that the index page actually renders
+
+from bs4 import BeautifulSoup
+
+from django.test import (
+    TestCase,
+)
+from django.urls import reverse
+from core.test.test_base import RequestFactoryBase
+
+
+class ViewAdminLink(TestCase, RequestFactoryBase):
+    def setUp(self):
+        RequestFactoryBase.__init__(self)
+
+        self.client.login(
+            username=self.test_user_email,
+            password=self.test_password,
+        )
+
+    def test_user_can_view_admin_link(self):
+        """
+        Test admin user can view Admin link in navigation bar
+        """
+        # Create staff user
+        self.test_user.is_staff
+        self.test_user.save()
+
+        view_homepage = reverse(
+            "index",
+        )
+
+        response = self.client.get(view_homepage)
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.content, features="html.parser")
+
+        admin_link = soup.find_all("a", class_="admin_page")
+
+        assert len(admin_link) == 1
+
+    def test_user_cannot_view_admin_link(self):
+        """
+        Test admin user cannot view Admin link in navigation bar
+        """
+
+        view_homepage = reverse(
+            "index",
+        )
+
+        response = self.client.get(view_homepage)
+        assert response.status_code == 200
+
+        soup = BeautifulSoup(response.content, features="html.parser")
+
+        admin_link = soup.find_all("a", class_="admin_page")
+
+        assert len(admin_link) == 0

--- a/features/steps/view_admin_link.py
+++ b/features/steps/view_admin_link.py
@@ -7,6 +7,7 @@ from behave import (
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
+from selenium.common.exceptions import NoSuchElementException
 
 from features.environment import (
     create_test_user,
@@ -28,8 +29,11 @@ def step_impl(context):
 
 @then(u'I should see a link to the admin website')
 def step_impl(context):
-    admin_link = context.browser.find_element_by_id(
-        "admin_link"
-    )
+    try:
+        context.browser.find_element_by_id(
+            "admin_page"
+        )
+    except NoSuchElementException:
+        return False
+    return True
 
-    assert admin_link == True

--- a/features/steps/view_admin_link.py
+++ b/features/steps/view_admin_link.py
@@ -1,0 +1,35 @@
+from behave import (
+    given,
+    when,
+    then,
+)
+
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+
+from features.environment import (
+    create_test_user,
+)
+
+
+@given(u'I have admin site access')
+def step_impl(context):
+    create_test_user(context)
+    context.browser.get(f'{context.base_url}/')
+
+
+@when(u'I access the FFT website')
+def step_impl(context):
+    WebDriverWait(context.browser, 500).until(
+        ec.presence_of_element_located((By.ID, "admin_page"))
+    )
+
+
+@then(u'I should see a link to the admin website')
+def step_impl(context):
+    admin_link = context.browser.find_element_by_id(
+        "admin_link"
+    )
+
+    assert admin_link == True

--- a/features/view_admin_link.feature
+++ b/features/view_admin_link.feature
@@ -1,0 +1,6 @@
+Feature: View Admin Link on Navigation Bar
+
+  Scenario: If users have admin access a link should be shown to the admin site
+    Given I have admin site access
+     When I access the FFT website
+     Then I should see a link to the admin website


### PR DESCRIPTION
If users have admin access a link should be shown to the admin site. If not, the user should not be able to see a link to the admin site.