### PR TITLE
Amend add row logic in line with Elena comments

### DIFF
--- a/forecast/forms.py
+++ b/forecast/forms.py
@@ -27,7 +27,24 @@ class PublishForm(forms.Form):
 
 
 class AddForecastRowForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        self.__cost_centre_code = kwargs.pop("cost_centre_code")
+        forms.Form.__init__(self, *args, **kwargs)
+
+    @property
+    def cost_centre_code(self):
+        return self.__cost_centre_code
+
+    @cost_centre_code.setter
+    def cost_centre_code(self, value):
+        self.__cost_centre_code = value
+
     def clean(self):
+        if not self.__cost_centre_code:
+            raise forms.ValidationError(
+                "A cost centre must be set on this form"
+            )
+
         cleaned_data = super().clean()
         programme = cleaned_data.get("programme")
         natural_account_code = cleaned_data.get("natural_account_code")
@@ -41,6 +58,7 @@ class AddForecastRowForm(forms.Form):
             analysis1_code=analysis1_code,
             analysis2_code=analysis2_code,
             project_code=project_code,
+            cost_centre=self.__cost_centre_code,
         ).first()
 
         if financial_code:

--- a/forecast/forms.py
+++ b/forecast/forms.py
@@ -31,20 +31,7 @@ class AddForecastRowForm(forms.Form):
         self.__cost_centre_code = kwargs.pop("cost_centre_code")
         forms.Form.__init__(self, *args, **kwargs)
 
-    @property
-    def cost_centre_code(self):
-        return self.__cost_centre_code
-
-    @cost_centre_code.setter
-    def cost_centre_code(self, value):
-        self.__cost_centre_code = value
-
     def clean(self):
-        if not self.__cost_centre_code:
-            raise forms.ValidationError(
-                "A cost centre must be set on this form"
-            )
-
         cleaned_data = super().clean()
         programme = cleaned_data.get("programme")
         natural_account_code = cleaned_data.get("natural_account_code")

--- a/forecast/test/test_forms.py
+++ b/forecast/test/test_forms.py
@@ -48,7 +48,8 @@ class TestAddForecastRowForm(TestCase):
 
     def test_valid_data(self):
         form = AddForecastRowForm(
-            {
+            cost_centre_code=self.cost_centre_code,
+            data={
                 "programme": self.programme.programme_code,
                 "natural_account_code": self.nac_code,
                 "analysis1_code": self.analysis_1.analysis1_code,
@@ -60,7 +61,10 @@ class TestAddForecastRowForm(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_blank_data(self):
-        form = AddForecastRowForm({})
+        form = AddForecastRowForm(
+            cost_centre_code=self.cost_centre_code,
+            data={},
+        )
         self.assertFalse(form.is_valid())
         self.assertEqual(
             form.errors,
@@ -88,7 +92,8 @@ class TestAddForecastRowForm(TestCase):
         monthly_figure.save()
 
         form = AddForecastRowForm(
-            {
+            cost_centre_code=self.cost_centre_code,
+            data={
                 "programme": self.programme.programme_code,
                 "natural_account_code": self.nac_code,
                 "analysis1_code": self.analysis_1.analysis1_code,
@@ -126,7 +131,8 @@ class TestAddForecastRowForm(TestCase):
         monthly_figure.save()
 
         form = AddForecastRowForm(
-            {
+            cost_centre_code=self.cost_centre_code,
+            data={
                 "programme": self.programme.programme_code,
                 "natural_account_code": self.nac_code,
                 "analysis1_code": None,

--- a/forecast/views/edit_forecast.py
+++ b/forecast/views/edit_forecast.py
@@ -154,8 +154,14 @@ class AddRowView(
             "cost_centre_code": cost_centre.cost_centre_code,
         }
 
-    def form_valid(self, form):
+    def get_form_kwargs(self):
         self.get_cost_centre()
+
+        kwargs = super(AddRowView, self).get_form_kwargs()
+        kwargs['cost_centre_code'] = self.cost_centre_code
+        return kwargs
+
+    def form_valid(self, form):
         data = form.cleaned_data
 
         financial_code = FinancialCode.objects.filter(


### PR DESCRIPTION
Amend add row logic so that it is possible to have the same NAC and programme codes for forecast rows in different cost centres.