### PR TITLE
Hotfix/upload forecast

### DIFF
--- a/chartofaccountDIT/import_csv.py
+++ b/chartofaccountDIT/import_csv.py
@@ -52,11 +52,11 @@ ANALYSIS2_KEY = {
 
 
 def import_Analysis1(csvfile):
-    import_obj(csvfile, ANALYSIS1_KEY)
+    return import_obj(csvfile, ANALYSIS1_KEY)
 
 
 def import_Analysis2(csvfile):
-    import_obj(csvfile, ANALYSIS2_KEY)
+    return import_obj(csvfile, ANALYSIS2_KEY)
 
 
 import_a1_class = ImportInfo(ANALYSIS1_KEY)
@@ -102,7 +102,7 @@ NAC_KEY = {
 
 
 def import_NAC(csvfile):
-    import_obj(csvfile, NAC_KEY)
+    return import_obj(csvfile, NAC_KEY)
 
 
 def fix_L5_ref():
@@ -153,7 +153,7 @@ NAC_DIT_KEY = {
 
 
 def import_NAC_DIT(csvfile):
-    import_obj(csvfile, NAC_DIT_KEY)
+    return import_obj(csvfile, NAC_DIT_KEY)
 
 
 import_NAC_DIT_class = ImportInfo(NAC_DIT_KEY)
@@ -167,7 +167,7 @@ NAC_CATEGORY_KEY = {
 
 
 def import_NAC_expenditure_category(csvfile):
-    import_obj(csvfile, NAC_CATEGORY_KEY)
+    return import_obj(csvfile, NAC_CATEGORY_KEY)
 
 
 import_NAC_category_class = ImportInfo(NAC_CATEGORY_KEY)
@@ -230,7 +230,7 @@ import_expenditure_category_class = ImportInfo(
 
 
 def import_NAC_category(csvfile):
-    import_list_obj(csvfile, NACCategory, "NAC_category_description")
+    return import_list_obj(csvfile, NACCategory, "NAC_category_description")
 
 
 COMMERCIAL_CATEGORY_KEY = {
@@ -245,7 +245,7 @@ COMMERCIAL_CATEGORY_KEY = {
 
 
 def import_commercial_category(csvfile):
-    import_obj(csvfile, COMMERCIAL_CATEGORY_KEY)
+    return import_obj(csvfile, COMMERCIAL_CATEGORY_KEY)
 
 
 import_comm_cat_class = ImportInfo(COMMERCIAL_CATEGORY_KEY)
@@ -268,7 +268,7 @@ PROG_KEY = {
 
 
 def import_programme(csvfile):
-    import_obj(csvfile, PROG_KEY)
+    return import_obj(csvfile, PROG_KEY)
 
 
 import_prog_class = ImportInfo(PROG_KEY)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -80,11 +80,21 @@ else:
                 'stream': sys.stdout,
             },
         },
+        'root': {
+            'handlers': ['stdout'],
+            'level': os.getenv('ROOT_LOG_LEVEL', 'INFO'),
+        },
         'loggers': {
-            'django.request': {
+            'django': {
                 'handlers': ['stdout', ],
-                'level': 'WARNING',
+                'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+                'propagate': True,
+            },
+            'forecast.import_csv': {
+                'handlers': ['stdout', ],
+                'level': 'INFO',
                 'propagate': True,
             },
         },
     }
+

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -45,6 +45,9 @@ LOGGING = {
         "ecs_formatter": {
             "()": ECSFormatter,
         },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
     },
     'handlers': {
         'ecs': {
@@ -52,10 +55,21 @@ LOGGING = {
             'stream': sys.stdout,
             'formatter': 'ecs_formatter',
         },
+        'stdout': {
+            'class': 'logging.StreamHandler',
+            'stream': sys.stdout,
+            'formatter': 'simple',
+            'level': 'INFO',
+        },
     },
     'loggers': {
         'django.request': {
             'handlers': ['ecs', ],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'forecast.import_csv': {
+            'handlers': ['stdout', ],
             'level': 'INFO',
             'propagate': True,
         },

--- a/core/management/commands/import_data.py
+++ b/core/management/commands/import_data.py
@@ -56,7 +56,9 @@ class Command(BaseCommand):
     # importing actual is a special case, because we need to specify the month
     def handle(self, *args, **options):
         path = options.get("csv_path")
-        print(path)
+        self.stdout.write(
+            self.style.SUCCESS(f"Processing file {path}.")
+        )
         importtype = options.get("type")
         # Windows-1252 or CP-1252, used because of a back quote
         csvfile = open(path, newline="", encoding="cp1252")

--- a/core/management/commands/import_data.py
+++ b/core/management/commands/import_data.py
@@ -64,8 +64,7 @@ class Command(BaseCommand):
             success, msg = IMPORT_TYPE[importtype](csvfile)
         except WrongChartOFAccountCodeException as ex:
             csvfile.close()
-            raise CommandError(f"Failure import {importtype}: {str(ex)}.")
-
+            raise CommandError(f"Failure import {importtype}: {str(ex)}")
         csvfile.close()
         if success:
             self.stdout.write(

--- a/core/management/commands/import_data.py
+++ b/core/management/commands/import_data.py
@@ -1,4 +1,7 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import (
+    BaseCommand,
+    CommandError,
+)
 
 from chartofaccountDIT.import_csv import (
     import_Analysis1,
@@ -14,7 +17,10 @@ from chartofaccountDIT.import_csv import (
 
 from costcentre.import_csv import import_cc
 
-from forecast.import_csv import import_adi_file
+from forecast.import_csv import (
+    WrongChartOFAccountCodeException,
+    import_adi_file,
+)
 
 from treasuryCOA.import_csv import import_treasury_COA
 
@@ -54,11 +60,16 @@ class Command(BaseCommand):
         importtype = options.get("type")
         # Windows-1252 or CP-1252, used because of a back quote
         csvfile = open(path, newline="", encoding="cp1252")
-        status, msg = IMPORT_TYPE[importtype](csvfile)
+        try:
+            success, msg = IMPORT_TYPE[importtype](csvfile)
+        except WrongChartOFAccountCodeException as ex:
+            csvfile.close()
+            raise CommandError(f"Failure import {importtype}: {str(ex)}.")
+
         csvfile.close()
-        if status:
+        if success:
             self.stdout.write(
                 self.style.SUCCESS(f"Successfully completed import {importtype}.")
             )
         else:
-            self.stdout.write(self.style.ERROR(f"Failure import {importtype}: {msg}."))
+            raise CommandError(f"Failure import {importtype}: {msg}.")

--- a/core/management/commands/importdata.py
+++ b/core/management/commands/importdata.py
@@ -54,5 +54,11 @@ class Command(BaseCommand):
         importtype = options.get("type")
         # Windows-1252 or CP-1252, used because of a back quote
         csvfile = open(path, newline="", encoding="cp1252")
-        IMPORT_TYPE[importtype](csvfile)
+        status, msg = IMPORT_TYPE[importtype](csvfile)
         csvfile.close()
+        if status:
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully completed import {importtype}.")
+            )
+        else:
+            self.stdout.write(self.style.ERROR(f"Failure import {importtype}: {msg}."))

--- a/costcentre/import_csv.py
+++ b/costcentre/import_csv.py
@@ -45,7 +45,7 @@ CC_KEY = {
 
 
 def import_cc(csvfile):
-    import_obj(csvfile, CC_KEY)
+    return import_obj(csvfile, CC_KEY)
 
 
 import_cc_class = ImportInfo(

--- a/forecast/import_csv.py
+++ b/forecast/import_csv.py
@@ -67,8 +67,7 @@ def import_adi_file(csvfile):
         )
 
         if check_financial_code.error_found:
-            print(f"Row {line} error: {check_financial_code.display_error}",)
-            return False
+            return False, f"Row {line} error: {check_financial_code.display_error}"
 
         financialcode_obj = check_financial_code.get_financial_code()
 
@@ -90,7 +89,7 @@ def import_adi_file(csvfile):
 
         if (line % 100) == 0:
             print(line)
-    return True
+    return True, "Import completed successfully."
 
 
 h_list = [

--- a/forecast/import_csv.py
+++ b/forecast/import_csv.py
@@ -1,13 +1,5 @@
 import csv
 
-from chartofaccountDIT.models import (
-    Analysis1,
-    Analysis2,
-    NaturalCode,
-    ProgrammeCode,
-    ProjectCode,
-)
-
 from core.import_csv import (
     ImportInfo,
     csv_header_to_dict,
@@ -16,14 +8,12 @@ from core.import_csv import (
 )
 from core.myutils import get_current_financial_year
 
-from costcentre.models import CostCentre
-
 from forecast.models import (
-    FinancialCode,
     FinancialPeriod,
     FinancialYear,
     ForecastMonthlyFigure,
 )
+from forecast.utils.import_helpers import CheckFinancialCode
 
 
 def get_month_dict():
@@ -52,60 +42,55 @@ def import_adi_file(csvfile):
     fin_year = get_current_financial_year()
     # Clear the table first. The adi file has several lines with the same key,
     # so the figures have to be added and we don't want to add to existing data!
-    ForecastMonthlyFigure.objects.filter(financial_year=fin_year).delete()
+    ForecastMonthlyFigure.objects.filter(
+        financial_year=fin_year,
+        archived_status__isnull=True
+    ).delete()
     reader = csv.reader(csvfile)
     col_key = csv_header_to_dict(next(reader))
     line = 1
     fin_obj, msg = get_fk(FinancialYear, fin_year)
     month_dict = get_month_dict()
+    check_financial_code = CheckFinancialCode(None)
+
     csv_reader = csv.reader(csvfile, delimiter=",", quotechar='"')
     for row in csv_reader:
         line += 1
-        err_msg = ""
-        cc_obj, msg = get_fk(CostCentre, row[col_key["cost centre"]].strip())
-        err_msg += msg
-        nac_obj, msg = get_fk(NaturalCode, row[col_key["natural account"]].strip())
-        err_msg += msg
-        prog = row[col_key["programme"]].strip()
-        prog_obj, msg = get_fk(ProgrammeCode, prog)
-        err_msg += msg
-        an1_obj, msg = get_fk(Analysis1, int(row[col_key["analysis"]]))
-        an2_obj, msg = get_fk(Analysis2, int(row[col_key["analysis2"]]))
-        proj_obj, msg = get_fk(ProjectCode, row[col_key["project"]].strip())
-        # Now read the twelve month values into a dict
-        if err_msg == "":
-            financial_code, created = FinancialCode.objects.get_or_create(
-                programme=prog_obj,
-                cost_centre=cc_obj,
-                natural_account_code=nac_obj,
-                analysis1_code=an1_obj,
-                analysis2_code=an2_obj,
-                project_code=proj_obj,
-            )
-            if created:
-                financial_code.save()
+        programme_code = row[col_key["programme"]].strip()
+        cost_centre = row[col_key["cost centre"]].strip()
+        nac = row[col_key["natural account"]].strip()
+        analysis1 = row[col_key["analysis"]].strip()
+        analysis2 = row[col_key["analysis2"]].strip()
+        project_code = row[col_key["project"]].strip()
+        check_financial_code.validate(
+            cost_centre, nac, programme_code, analysis1, analysis2, project_code, line
+        )
 
-            for month, per_obj in month_dict.items():
-                period_amount = int(row[col_key[month.lower()]])
-                if period_amount:
-                    month_figure_obj, created = \
-                        ForecastMonthlyFigure.objects.get_or_create(
-                            financial_year=fin_obj,
-                            financial_period=per_obj,
-                            financial_code=financial_code,
-                        )
-                    if created:
-                        month_figure_obj.amount = period_amount * 100
-                    else:
-                        month_figure_obj.amount += (period_amount * 100)
-                    month_figure_obj.current_amount = month_figure_obj.amount
-                    month_figure_obj.save()
-        else:
-            print(line, err_msg)
+        if check_financial_code.error_found:
+            print(f"Row {line} error: {check_financial_code.display_error}",)
+            return False
+
+        financialcode_obj = check_financial_code.get_financial_code()
+
+        for month, per_obj in month_dict.items():
+            period_amount = int(row[col_key[month.lower()]])
+            if period_amount:
+                month_figure_obj, created = \
+                    ForecastMonthlyFigure.objects.get_or_create(
+                        financial_year=fin_obj,
+                        financial_period=per_obj,
+                        financial_code=financialcode_obj,
+                    )
+                if created:
+                    month_figure_obj.amount = period_amount * 100
+                else:
+                    month_figure_obj.amount += (period_amount * 100)
+                month_figure_obj.current_amount = month_figure_obj.amount
+                month_figure_obj.save()
 
         if (line % 100) == 0:
             print(line)
-    return True, err_msg
+    return True
 
 
 h_list = [

--- a/forecast/import_csv.py
+++ b/forecast/import_csv.py
@@ -16,6 +16,7 @@ from forecast.models import (
 )
 from forecast.utils.import_helpers import CheckFinancialCode
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/forecast/import_csv.py
+++ b/forecast/import_csv.py
@@ -1,5 +1,4 @@
 import csv
-
 import logging
 
 from core.import_csv import (

--- a/forecast/test/test_import_forecast.py
+++ b/forecast/test/test_import_forecast.py
@@ -1,0 +1,7 @@
+import io
+header = 'Entity,Cost Centre,Natural Account,Programme,Analysis,Analysis2,Project,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC,JAN,FEB,MAR,ADJ01,ADJ02,ADJ03,Total'
+line1 = '3000,109001,51111001,310530,0,0,0,22590,-57372,26955,26956,26957,26958,26959,26960,26961,26962,26963,26964,0,0,0,234814'
+line2 = '3000,109001,51111006,310530,0,0,0,45076,0,0,0,0,0,0,0,0,0,0,0,0,0,0,45076'
+line3 = '3000,109001,51112001,310530,0,0,0,2317,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2317'
+
+csvfile = io.StringIO (f'{header}\n{line1}\n{line2}\n{line3}\n')

--- a/forecast/test/test_import_forecast.py
+++ b/forecast/test/test_import_forecast.py
@@ -1,8 +1,8 @@
 import io
+
 from django.test import (
     RequestFactory,
     TestCase,
-    override_settings,
 )
 
 from chartofaccountDIT.test.factories import (
@@ -34,32 +34,38 @@ class ImportBudgetsTest(TestCase, RequestFactoryBase):
         self.test_year = 2019
         self.test_period = 9
         self.factory = RequestFactory()
-        self.cost_centre_code = '109189'
+        self.cost_centre_code = "109189"
         self.natural_account_code = 52191003
         self.programme_code = "310940"
-        self.project_code = '0123'
-        self.analisys1 = '00798'
-        self.analisys2 = '00321'
+        self.project_code = "0123"
+        self.analisys1 = "00798"
+        self.analisys2 = "00321"
         self.test_amount = 100
         self.directorate_obj = DirectorateFactory.create(directorate_code="T123")
         CostCentreFactory.create(
             cost_centre_code=self.cost_centre_code, directorate=self.directorate_obj
         )
         NaturalCodeFactory.create(
-            natural_account_code=self.natural_account_code, economic_budget_code='CAPITAL'
+            natural_account_code=self.natural_account_code,
+            economic_budget_code="CAPITAL",
         )
         ProgrammeCodeFactory.create(programme_code=self.programme_code)
-        ProjectCodeFactory.create(project_code = self.project_code)
-        Analysis1Factory.create(analysis1_code = self.analisys1)
-        Analysis2Factory.create(analysis2_code = self.analisys2)
+        ProjectCodeFactory.create(project_code=self.project_code)
+        Analysis1Factory.create(analysis1_code=self.analisys1)
+        Analysis2Factory.create(analysis2_code=self.analisys2)
         self.year_obj = FinancialYear.objects.get(financial_year=2019)
         self.year_obj.current = True
         self.year_obj.save
 
     def get_csv_data(self):
-        header = 'Entity,Cost Centre,Natural Account,Programme,Analysis,Analysis2,Project,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC,JAN,FEB,MAR,ADJ01,ADJ02,ADJ03'
-        line1 = f'3000,{self.cost_centre_code},{self.natural_account_code},{self.programme_code},{self.analisys1},{self.analisys2},{self.project_code},0,200,300,400,500,600,700,800,900,1000,1100,1200,0,0,0'
-        return  io.StringIO(f'{header}\n{line1}\n')
+        header = "Entity,Cost Centre,Natural Account,Programme,Analysis,Analysis2," \
+                 "Project,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC,JAN,FEB,MAR," \
+                 "ADJ01,ADJ02,ADJ03"
+        line1 = f"3000,{self.cost_centre_code},{self.natural_account_code}," \
+                f"{self.programme_code},{self.analisys1},{self.analisys2}," \
+                f"{self.project_code}," \
+                f"0,200,300,400,500,600,700,800,900,1000,1100,1200,0,0,0"
+        return io.StringIO(f"{header}\n{line1}\n")
 
     def test_upload_budget_report(self):
         result = import_adi_file(self.get_csv_data())
@@ -67,25 +73,13 @@ class ImportBudgetsTest(TestCase, RequestFactoryBase):
         self.assertEqual(
             ForecastMonthlyFigure.objects.all().count(), 11,
         )
-        self.assertEqual(
-            FinancialCode.objects.all().count(), 1
-        )
+        self.assertEqual(FinancialCode.objects.all().count(), 1)
         financial_code_obj = FinancialCode.objects.all().first()
-        self.assertEqual(
-            financial_code_obj.cost_centre_id, self.cost_centre_code
-        )
-        self.assertEqual(
-            financial_code_obj.analysis1_code_id, self.analisys1
-        )
-        self.assertEqual(
-            financial_code_obj.analysis2_code_id, self.analisys2
-        )
-        self.assertEqual(
-            financial_code_obj.project_code_id, self.project_code
-        )
-        self.assertEqual(
-            financial_code_obj.programme_id, self.programme_code
-        )
+        self.assertEqual(financial_code_obj.cost_centre_id, self.cost_centre_code)
+        self.assertEqual(financial_code_obj.analysis1_code_id, self.analisys1)
+        self.assertEqual(financial_code_obj.analysis2_code_id, self.analisys2)
+        self.assertEqual(financial_code_obj.project_code_id, self.project_code)
+        self.assertEqual(financial_code_obj.programme_id, self.programme_code)
         self.assertEqual(
             financial_code_obj.natural_account_code_id, self.natural_account_code
         )

--- a/forecast/test/test_import_forecast.py
+++ b/forecast/test/test_import_forecast.py
@@ -1,7 +1,91 @@
 import io
-header = 'Entity,Cost Centre,Natural Account,Programme,Analysis,Analysis2,Project,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC,JAN,FEB,MAR,ADJ01,ADJ02,ADJ03,Total'
-line1 = '3000,109001,51111001,310530,0,0,0,22590,-57372,26955,26956,26957,26958,26959,26960,26961,26962,26963,26964,0,0,0,234814'
-line2 = '3000,109001,51111006,310530,0,0,0,45076,0,0,0,0,0,0,0,0,0,0,0,0,0,0,45076'
-line3 = '3000,109001,51112001,310530,0,0,0,2317,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2317'
+from django.test import (
+    RequestFactory,
+    TestCase,
+    override_settings,
+)
 
-csvfile = io.StringIO (f'{header}\n{line1}\n{line2}\n{line3}\n')
+from chartofaccountDIT.test.factories import (
+    Analysis1Factory,
+    Analysis2Factory,
+    NaturalCodeFactory,
+    ProgrammeCodeFactory,
+    ProjectCodeFactory,
+)
+
+from core.models import FinancialYear
+from core.test.test_base import RequestFactoryBase
+
+from costcentre.test.factories import (
+    CostCentreFactory,
+    DirectorateFactory,
+)
+
+from forecast.import_csv import import_adi_file
+from forecast.models import (
+    FinancialCode,
+    ForecastMonthlyFigure,
+)
+
+
+class ImportBudgetsTest(TestCase, RequestFactoryBase):
+    def setUp(self):
+        RequestFactoryBase.__init__(self)
+        self.test_year = 2019
+        self.test_period = 9
+        self.factory = RequestFactory()
+        self.cost_centre_code = '109189'
+        self.natural_account_code = 52191003
+        self.programme_code = "310940"
+        self.project_code = '0123'
+        self.analisys1 = '00798'
+        self.analisys2 = '00321'
+        self.test_amount = 100
+        self.directorate_obj = DirectorateFactory.create(directorate_code="T123")
+        CostCentreFactory.create(
+            cost_centre_code=self.cost_centre_code, directorate=self.directorate_obj
+        )
+        NaturalCodeFactory.create(
+            natural_account_code=self.natural_account_code, economic_budget_code='CAPITAL'
+        )
+        ProgrammeCodeFactory.create(programme_code=self.programme_code)
+        ProjectCodeFactory.create(project_code = self.project_code)
+        Analysis1Factory.create(analysis1_code = self.analisys1)
+        Analysis2Factory.create(analysis2_code = self.analisys2)
+        self.year_obj = FinancialYear.objects.get(financial_year=2019)
+        self.year_obj.current = True
+        self.year_obj.save
+
+    def get_csv_data(self):
+        header = 'Entity,Cost Centre,Natural Account,Programme,Analysis,Analysis2,Project,APR,MAY,JUN,JUL,AUG,SEP,OCT,NOV,DEC,JAN,FEB,MAR,ADJ01,ADJ02,ADJ03'
+        line1 = f'3000,{self.cost_centre_code},{self.natural_account_code},{self.programme_code},{self.analisys1},{self.analisys2},{self.project_code},0,200,300,400,500,600,700,800,900,1000,1100,1200,0,0,0'
+        return  io.StringIO(f'{header}\n{line1}\n')
+
+    def test_upload_budget_report(self):
+        result = import_adi_file(self.get_csv_data())
+        self.assert_(result, True)
+        self.assertEqual(
+            ForecastMonthlyFigure.objects.all().count(), 11,
+        )
+        self.assertEqual(
+            FinancialCode.objects.all().count(), 1
+        )
+        financial_code_obj = FinancialCode.objects.all().first()
+        self.assertEqual(
+            financial_code_obj.cost_centre_id, self.cost_centre_code
+        )
+        self.assertEqual(
+            financial_code_obj.analysis1_code_id, self.analisys1
+        )
+        self.assertEqual(
+            financial_code_obj.analysis2_code_id, self.analisys2
+        )
+        self.assertEqual(
+            financial_code_obj.project_code_id, self.project_code
+        )
+        self.assertEqual(
+            financial_code_obj.programme_id, self.programme_code
+        )
+        self.assertEqual(
+            financial_code_obj.natural_account_code_id, self.natural_account_code
+        )

--- a/forecast/test/test_views.py
+++ b/forecast/test/test_views.py
@@ -595,9 +595,9 @@ class ViewForecastHierarchyTest(TestCase, RequestFactoryBase):
         project_rows = table.find_all("tr")
         first_project_cols = project_rows[2].find_all("td")
 
-        assert first_project_cols[1].get_text().strip() == \
+        assert first_project_cols[0].get_text().strip() == \
             self.project_obj.project_description
-        assert first_project_cols[2].get_text().strip() == self.project_obj.project_code
+        assert first_project_cols[1].get_text().strip() == self.project_obj.project_code
         assert first_project_cols[3].get_text().strip() == format_forecast_figure(
             self.budget / 100
         )

--- a/forecast/utils/import_helpers.py
+++ b/forecast/utils/import_helpers.py
@@ -236,7 +236,11 @@ class CheckFinancialCode:
 
     def __init__(self, file_upload):
         self.file_upload = file_upload
-        self.upload_type = self.file_upload.document_type
+        if self.file_upload:
+            self.upload_type = self.file_upload.document_type
+        else:
+            # This is uploaded from a command, and there is no document type defined
+            self.upload_type = "Forecast"
         self.error_found = False
         self.warning_found = False
         self.nac_dict = {}
@@ -353,17 +357,18 @@ class CheckFinancialCode:
         self.analysis2_obj = self.validate_analysis2(analysis2)
         self.project_obj = self.validate_project(project)
 
-        if self.display_warning:
+        if self.display_warning and self.file_upload:
             set_file_upload_warning(
                 self.file_upload, f"Row {row_number} warning: {self.display_warning}"
             )
 
         if self.display_error:
-            set_file_upload_error(
-                self.file_upload,
-                f"Row {row_number} error: {self.display_error}",
-                "Upload aborted: Data error.",
-            )
+            if self.file_upload:
+                set_file_upload_error(
+                    self.file_upload,
+                    f"Row {row_number} error: {self.display_error}",
+                    "Upload aborted: Data error.",
+                )
         return self.error_found
 
     def get_financial_code(self):

--- a/forecast/utils/query_fields.py
+++ b/forecast/utils/query_fields.py
@@ -116,19 +116,19 @@ expenditure_order_list = [
 
 # Project data
 project_columns = {
-    FORECAST_EXPENDITURE_TYPE_ORDER: "Hidden",
-    FORECAST_EXPENDITURE_TYPE_NAME: "Expenditure type",
     PROJECT_NAME: "Project",
     PROJECT_CODE: "code",
+    FORECAST_EXPENDITURE_TYPE_ORDER: "Hidden",
+    FORECAST_EXPENDITURE_TYPE_NAME: "Expenditure type",
 }
 project_order_list = [
-    FORECAST_EXPENDITURE_TYPE_ORDER,
     PROJECT_CODE,
+    FORECAST_EXPENDITURE_TYPE_ORDER,
 ]
 project_sub_total = [
-    FORECAST_EXPENDITURE_TYPE_NAME,
+    PROJECT_NAME,
 ]
-project_display_sub_total_column = PROJECT_NAME
+project_display_sub_total_column = PROJECT_CODE
 
 project_detail_view = [
     'project_details_dit',

--- a/treasuryCOA/import_csv.py
+++ b/treasuryCOA/import_csv.py
@@ -108,7 +108,7 @@ L5_KEY = {
 
 
 def import_treasury_COA(csvfile):
-    import_obj(csvfile, L5_KEY)
+    return import_obj(csvfile, L5_KEY)
 
 
 import_L5_class = ImportInfo(L5_KEY, "Treasury Chart of Account")


### PR DESCRIPTION
Change the logic used to verify the chart of account when uploading the forecast from a csv file.
Previously, Project code shorter than 4 characters were ignored, and the row was saved without a project code.
Similar problem with analysis1 and analysis2.
The new logic right pad the code with zeros to the expected fixed size, and stop uploading if a code cannot be found.

