### PR TITLE
Programme code cannot be edited from the Admin Interface

### DIFF
--- a/chartofaccountDIT/admin.py
+++ b/chartofaccountDIT/admin.py
@@ -415,6 +415,8 @@ class ProgrammeAdmin(AdminActiveField, AdminImportExtraExport):
         if request.user.is_superuser:
             if obj:
                 return["created", "updated"]
+            else:
+                return ["created", "updated"]
         elif request.user.groups.filter(name="Finance Administrator"):
             if obj:
                 return [
@@ -425,6 +427,8 @@ class ProgrammeAdmin(AdminActiveField, AdminImportExtraExport):
                 ]  # don't allow to edit the code
             else:
                 return ["created", "updated"]
+        else:
+            return self.get_fields(request, obj)
 
     def get_fields(self, request, obj=None):
         return [

--- a/chartofaccountDIT/admin.py
+++ b/chartofaccountDIT/admin.py
@@ -399,24 +399,32 @@ class NACCategoryAdmin(AdminImportExport):
         return import_NAC_category_class
 
 
-class ProgrammeAdmin(AdminActiveField, AdminImportExport):
+class ProgrammeAdmin(AdminActiveField, AdminImportExtraExport):
+    change_list_template = "admin/m_import_changelist.html"
+
     list_display = (
         "programme_code",
         "programme_description",
         "budget_type_fk",
         "active",
+        "created",
+        "updated",
     )
-    search_fields = ["programme_code", "programme_description"]
-    list_filter = ["budget_type_fk", "active"]
 
     def get_readonly_fields(self, request, obj=None):
-        return [
-            "programme_code",
-            "programme_description",
-            "budget_type_fk",
-            "created",
-            "updated",
-        ]  # don't allow to edit the code
+        if request.user.is_superuser:
+            if obj:
+                return["created", "updated"]
+        elif request.user.groups.filter(name="Finance Administrator"):
+            if obj:
+                return [
+                    "programme_code",
+                    "budget_type_fk",
+                    "created",
+                    "updated",
+                ]  # don't allow to edit the code
+            else:
+                return ["created", "updated"]
 
     def get_fields(self, request, obj=None):
         return [
@@ -427,6 +435,9 @@ class ProgrammeAdmin(AdminActiveField, AdminImportExport):
             "created",
             "updated",
         ]
+
+    search_fields = ["programme_code", "programme_description"]
+    list_filter = ["budget_type_fk", "active"]
 
     @property
     def export_func(self):

--- a/chartofaccountDIT/admin.py
+++ b/chartofaccountDIT/admin.py
@@ -413,10 +413,7 @@ class ProgrammeAdmin(AdminActiveField, AdminImportExtraExport):
 
     def get_readonly_fields(self, request, obj=None):
         if request.user.is_superuser:
-            if obj:
-                return["created", "updated"]
-            else:
-                return ["created", "updated"]
+            return["created", "updated"]
         elif request.user.groups.filter(name="Finance Administrator"):
             if obj:
                 return [


### PR DESCRIPTION
Finance Administrators need to add Programme Codes, or edit existing one.

Currently, every field is read only, and there is no way to add a new one. This PR allows Finance Admins to edit the existing Programme Code description and add new Programme Codes.

This applies to full administrators too.