### PR TITLE
Icon on Admin site for Cost Centres display as pencil

### DIFF
--- a/costcentre/admin.py
+++ b/costcentre/admin.py
@@ -330,7 +330,7 @@ class CostCentreAdmin(GuardedModelAdminMixin, AdminActiveField, AdminImportExtra
 
     def has_change_permission(self, request, obj=None):
         if not obj:
-            return False
+            return True
 
         cost_centre = self.get_object(request, obj.pk)
 


### PR DESCRIPTION
In the Admin interface,Finance Administrator should see the 'pencil' icon next to Cost Centre, instead of the 'eye' icon, because they can edit Cost Centres.