### PR TITLE
Remove user email address from user search and cost centre user selection

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -301,7 +301,7 @@ class UserListFilter(admin.SimpleListFilter):
 
             return queryset.exclude(
                 pk__in=id_list
-            ).order_by("-first_name")
+            ).order_by("-last_name")
 
         return queryset
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -301,13 +301,15 @@ class UserListFilter(admin.SimpleListFilter):
 
             return queryset.exclude(
                 pk__in=id_list
-            ).order_by("-email")
+            ).order_by("-first_name")
 
         return queryset
 
 
 class UserAdmin(UserAdmin):
     list_filter = (UserListFilter,)
+    list_display = ('first_name', 'last_name',
+                    'is_active', 'is_staff', 'is_superuser')
 
     def save_model(self, request, obj, form, change):
         for group in form.cleaned_data["groups"]:
@@ -346,7 +348,6 @@ class UserAdmin(UserAdmin):
         return [
             "first_name",
             "last_name",
-            "email",
             "last_login",
             "is_superuser",
             "user_permissions",

--- a/core/export_data.py
+++ b/core/export_data.py
@@ -2,11 +2,10 @@ from core.exportutils import get_fk_value
 
 
 def export_logentry_iterator(queryset):
-    yield ["Action Time", "User Email", "Content Type", "Action Flag", "Change Message"]
+    yield ["Action Time", "Content Type", "Action Flag", "Change Message"]
     for obj in queryset:
         yield [
             obj.action_time,
-            obj.user.email,
             get_fk_value(obj.content_type, "name"),
             obj.action_flag,
             obj.change_message

--- a/costcentre/admin.py
+++ b/costcentre/admin.py
@@ -505,7 +505,7 @@ class BusinessPartnerAdmin(AdminActiveField, AdminExport):
 
 class CostCentrePersonAdmin(AdminActiveField, AdminExport):
     list_display = ("full_name", "is_dg", "is_director", "active")
-    search_fields = ["name", "surname", "email"]
+    search_fields = ["name", "surname"]
 
     list_filter = ("active", "is_director", "is_dg")
 

--- a/costcentre/admin.py
+++ b/costcentre/admin.py
@@ -505,7 +505,7 @@ class BusinessPartnerAdmin(AdminActiveField, AdminExport):
 
 class CostCentrePersonAdmin(AdminActiveField, AdminExport):
     list_display = ("full_name", "is_dg", "is_director", "active")
-    search_fields = ["name", "surname"]
+    search_fields = ["name", "last_name"]
 
     list_filter = ("active", "is_director", "is_dg")
 

--- a/costcentre/forms.py
+++ b/costcentre/forms.py
@@ -135,7 +135,7 @@ class GivePermissionAdminForm(forms.Form):
         # Set list of users removing administering user
         self.base_fields['user'].queryset = User.objects.exclude(
             pk__in=id_list
-        ).order_by("-email")
+        ).order_by("-first_name")
 
         super(GivePermissionAdminForm, self).__init__(
             *args,

--- a/costcentre/templates/costcentre/admin/change_permission_form.html
+++ b/costcentre/templates/costcentre/admin/change_permission_form.html
@@ -44,7 +44,6 @@
                     <th></th>
                     <th scope="col" class="sortable column-user_email">First name</th>
                     <th scope="col" class="sortable column-user_first_name">Last name</th>
-                    <th scope="col" class="sortable column-user_last_name">Email address</th>
                 </tr>
             </thead>
             <tbody>
@@ -55,7 +54,6 @@
                         </td>
                         <td>{{ user.first_name }}</td>
                         <td>{{ user.last_name }}</td>
-                        <td>{{ user.email }}</td>
                     </tr>
                 {% endfor %}
                 <tr>

--- a/forecast/admin.py
+++ b/forecast/admin.py
@@ -67,7 +67,7 @@ class UnlockedForecastEditorAdmin(admin.ModelAdmin):
             UnlockedForecastEditorAdmin,
             self,
         ).get_form(request, **kwargs)
-        unlock_form.current_user = request.user.id
+        unlock_form.current_user = request.user
         return unlock_form
 
 

--- a/forecast/admin.py
+++ b/forecast/admin.py
@@ -67,7 +67,7 @@ class UnlockedForecastEditorAdmin(admin.ModelAdmin):
             UnlockedForecastEditorAdmin,
             self,
         ).get_form(request, **kwargs)
-        unlock_form.current_user = request.user
+        unlock_form.current_user = request.user.id
         return unlock_form
 
 

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -2,7 +2,6 @@ import copy
 
 from django.contrib.auth import get_user_model
 from django.db import models
-from django import forms
 from django.db.models import (
     Max,
     Q,

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -86,7 +86,7 @@ class UnlockedForecastEditor(BaseModel):
     )
 
     def __str__(self):
-        return self.user.name
+        return self.user
 
 
 class ForecastExpenditureType(BaseModel):

--- a/forecast/models.py
+++ b/forecast/models.py
@@ -2,6 +2,7 @@ import copy
 
 from django.contrib.auth import get_user_model
 from django.db import models
+from django import forms
 from django.db.models import (
     Max,
     Q,
@@ -86,7 +87,7 @@ class UnlockedForecastEditor(BaseModel):
     )
 
     def __str__(self):
-        return self.user.email
+        return self.user.name
 
 
 class ForecastExpenditureType(BaseModel):


### PR DESCRIPTION
We need to remove all traces of user email address from the admin site. The field should no longer be surfaced anywhere.