### PR TITLE
Hotfix/lst 1282 amend year checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
      - "6379:6379"
  selenium-hub:
     image: selenium/hub:3.141.59-vanadium
-    container_name: selenium-hub
+    container_name: selenium-hub_1
     ports:
       - "4444:4444"
  chrome:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
      - "6379:6379"
  selenium-hub:
     image: selenium/hub:3.141.59-vanadium
-    container_name: selenium-hub_1
+    container_name: selenium-hub
     ports:
       - "4444:4444"
  chrome:

--- a/forecast/import_actuals.py
+++ b/forecast/import_actuals.py
@@ -117,9 +117,9 @@ def save_trial_balance_row(
         monthlyfigure_obj.save()
 
 
-def check_trial_balance_format(worksheet, period, year):
+def check_trial_balance_format(worksheet, calendar_month_number, financial_year):
     """Check that the file is really the trial
-    balance and it is the correct period"""
+    balance and it is the correct month"""
 
     try:
         if worksheet[TITLE_CELL].value != CORRECT_TRIAL_BALANCE_TITLE:
@@ -138,7 +138,15 @@ def check_trial_balance_format(worksheet, period, year):
 
     try:
         report_date = worksheet[MONTH_CELL].value
-        if report_date.year != year:
+        # The year on the trial balance is the calendar year,
+        # and the upload year is the financial year
+        # They don't match in Jan, Feb, March
+        if calendar_month_number < 4:
+            year_to_check = financial_year + 1
+        else:
+            year_to_check = financial_year
+
+        if report_date.year != year_to_check:
             # wrong date
             raise UploadFileFormatError("File is for wrong year")
     except TypeError:
@@ -151,9 +159,9 @@ def check_trial_balance_format(worksheet, period, year):
             "This file appears to be corrupt and it cannot be read"
         )
 
-    if report_date.month != period:
+    if report_date.month != calendar_month_number:
         # wrong date
-        raise UploadFileFormatError("File is for wrong period")
+        raise UploadFileFormatError("File is for wrong month")
 
     return True
 

--- a/forecast/test/test_import_actuals.py
+++ b/forecast/test/test_import_actuals.py
@@ -550,6 +550,77 @@ class ImportActualsTest(BaseTestCase):
                 2019,
             )
 
+    def test_check_trial_balance_format_jan(self):
+        # The year on the trial balance is the calendar year,
+        # and the upload year is the financial year
+        # They don't match in Jan, Feb, March
+        upload_month = 1
+        fake_work_sheet = FakeWorkSheet()
+        fake_work_sheet.title = CORRECT_TRIAL_BALANCE_WORKSHEET_NAME
+        fake_work_sheet[TITLE_CELL] = FakeCell(CORRECT_TRIAL_BALANCE_TITLE)
+        fake_work_sheet[MONTH_CELL] = FakeCell(datetime(2020, upload_month, 1))
+        # wrong month
+        self.assertTrue(
+            check_trial_balance_format(
+                fake_work_sheet,
+                upload_month,
+                2019,
+            )
+        )
+
+
+    def test_check_trial_balance_format_dec(self):
+        upload_month = 12
+        fake_work_sheet = FakeWorkSheet()
+        fake_work_sheet.title = CORRECT_TRIAL_BALANCE_WORKSHEET_NAME
+        fake_work_sheet[TITLE_CELL] = FakeCell(CORRECT_TRIAL_BALANCE_TITLE)
+        fake_work_sheet[MONTH_CELL] = FakeCell(datetime(2019, upload_month, 1))
+        # wrong month
+        self.assertTrue(
+            check_trial_balance_format(
+                fake_work_sheet,
+                upload_month,
+                2019,
+            )
+        )
+
+
+    def test_check_trial_balance_format_feb(self):
+        # The year on the trial balance is the calendar year,
+        # and the upload year is the financial year
+        # They don't match in Jan, Feb, March
+        upload_month = 2
+        fake_work_sheet = FakeWorkSheet()
+        fake_work_sheet.title = CORRECT_TRIAL_BALANCE_WORKSHEET_NAME
+        fake_work_sheet[TITLE_CELL] = FakeCell(CORRECT_TRIAL_BALANCE_TITLE)
+        fake_work_sheet[MONTH_CELL] = FakeCell(datetime(2020, upload_month, 1))
+        # wrong month
+        self.assertTrue(
+            check_trial_balance_format(
+                fake_work_sheet,
+                upload_month,
+                2019,
+            )
+        )
+
+    def test_check_trial_balance_format_mar(self):
+        # The year on the trial balance is the calendar year,
+        # and the upload year is the financial year
+        # They don't match in Jan, Feb, March
+        upload_month = 3
+        fake_work_sheet = FakeWorkSheet()
+        fake_work_sheet.title = CORRECT_TRIAL_BALANCE_WORKSHEET_NAME
+        fake_work_sheet[TITLE_CELL] = FakeCell(CORRECT_TRIAL_BALANCE_TITLE)
+        fake_work_sheet[MONTH_CELL] = FakeCell(datetime(2020, upload_month, 1))
+        # wrong month
+        self.assertTrue(
+            check_trial_balance_format(
+                fake_work_sheet,
+                upload_month,
+                2019,
+            )
+        )
+
 
 # Set file upload handlers back to default as
 # we need to remove S3 interactions for test purposes

--- a/forecast/test/test_import_actuals.py
+++ b/forecast/test/test_import_actuals.py
@@ -568,7 +568,6 @@ class ImportActualsTest(BaseTestCase):
             )
         )
 
-
     def test_check_trial_balance_format_dec(self):
         upload_month = 12
         fake_work_sheet = FakeWorkSheet()
@@ -583,7 +582,6 @@ class ImportActualsTest(BaseTestCase):
                 2019,
             )
         )
-
 
     def test_check_trial_balance_format_feb(self):
         # The year on the trial balance is the calendar year,


### PR DESCRIPTION
The actual file uploaded to FFT, use the calendar year. This is different from the financial years in January, February and March. 
Corrected the check for the year to handle it.